### PR TITLE
Change Zipkin to Stackdriver ID translation to use entire 128-bit range.

### DIFF
--- a/translation/src/main/java/com/google/cloud/trace/zipkin/translation/TraceTranslator.java
+++ b/translation/src/main/java/com/google/cloud/trace/zipkin/translation/TraceTranslator.java
@@ -92,7 +92,7 @@ public class TraceTranslator {
   private String convertTraceId(long zipkinTraceId) {
     // Stackdriver trace ID's are 128 bits = 16 bytes * 8
     ByteBuffer idBuffer = ByteBuffer.allocate(16);
-    idBuffer.putLong(0);
+    idBuffer.putLong(zipkinTraceId);
     idBuffer.putLong(zipkinTraceId);
     StringBuilder idBuilder = new StringBuilder();
     for (byte b : idBuffer.array()) {

--- a/translation/src/test/java/com/google/cloud/trace/zipkin/translation/TraceTranslatorTest.java
+++ b/translation/src/test/java/com/google/cloud/trace/zipkin/translation/TraceTranslatorTest.java
@@ -76,8 +76,8 @@ public class TraceTranslatorTest {
         trace1.getTraceId(), trace1,
         trace2.getTraceId(), trace2
     );
-    String key1 = "00000000000000000000000000000001";
-    String key2 = "00000000000000000000000000000002";
+    String key1 = "00000000000000010000000000000001";
+    String key2 = "00000000000000020000000000000002";
     assertTrue(traceMap.containsKey(key1));
     assertTrue(traceMap.containsKey(key2));
     assertEquals(2, traceMap.get(key1).getSpansCount());


### PR DESCRIPTION
Change ID translation so that when translating from 64-bits to 128-bits, all 128 bits in the output may be used. This helps when the Stackdriver API returns traces sorted by ascending Trace IDs. A project with Stackdriver and Zipkin traces would likely return only Zipkin traces whereas we'd prefer that it return a random mix of both.