### PR TITLE
Updates to latest zipkin and switches to 128-bit trace IDs

### DIFF
--- a/autoconfigure-storage/pom.xml
+++ b/autoconfigure-storage/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin</artifactId>
-      <version>1.14.4</version>
+      <version>${zipkin.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin-server</artifactId>
-      <version>1.14.4</version>
+      <version>${zipkin.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <zipkin.version>1.18.0</zipkin.version>
+  </properties>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin</artifactId>
-      <version>1.14.4</version>
+      <version>${zipkin.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.trace</groupId>

--- a/translation/pom.xml
+++ b/translation/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin</artifactId>
-      <version>1.14.4</version>
+      <version>${zipkin.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.trace</groupId>

--- a/translation/src/main/java/com/google/cloud/trace/zipkin/translation/TraceTranslator.java
+++ b/translation/src/main/java/com/google/cloud/trace/zipkin/translation/TraceTranslator.java
@@ -55,7 +55,7 @@ public class TraceTranslator {
 
     Collection<Trace> translatedTraces = new ArrayList<>();
     for (Span zipkinSpan : groupedSpans) {
-      String traceId = convertTraceId(zipkinSpan.traceId);
+      String traceId = convertTraceId(zipkinSpan);
       if (currentTrace == null || !traceId.equals(currentTrace.getTraceId())) {
         finishTrace(currentTrace, translatedTraces);
 
@@ -89,11 +89,16 @@ public class TraceTranslator {
     }
   }
 
-  private String convertTraceId(long zipkinTraceId) {
+  static String convertTraceId(Span zipkinSpan) {
     // Stackdriver trace ID's are 128 bits = 16 bytes * 8
-    ByteBuffer idBuffer = ByteBuffer.allocate(16);
-    idBuffer.putLong(zipkinTraceId);
-    idBuffer.putLong(zipkinTraceId);
+    ByteBuffer idBuffer = ByteBuffer.allocate(16); // or 32 characters
+    // Some users call the Stackdriver API and order results by traceId to get a "random sample" of
+    // traces. Duplicating the 64-bit ID instead of padding the ID with zeros will remove some
+    // sampling bias for any projects that contain both Zipkin and Stackdriver traces. Regardless of
+    // if we pad-left 0s or duplicate traceId, this resulting ID won't match Zipkin anyway as it
+    // conditionally encodes 16 characters if high bits are unset (as opposed to padding to 32).
+    idBuffer.putLong(zipkinSpan.traceIdHigh == 0L ? zipkinSpan.traceId : zipkinSpan.traceIdHigh);
+    idBuffer.putLong(zipkinSpan.traceId);
     StringBuilder idBuilder = new StringBuilder();
     for (byte b : idBuffer.array()) {
       idBuilder.append(String.format("%02x", b));

--- a/translation/src/main/java/com/google/cloud/trace/zipkin/translation/TraceTranslator.java
+++ b/translation/src/main/java/com/google/cloud/trace/zipkin/translation/TraceTranslator.java
@@ -92,12 +92,8 @@ public class TraceTranslator {
   static String convertTraceId(Span zipkinSpan) {
     // Stackdriver trace ID's are 128 bits = 16 bytes * 8
     ByteBuffer idBuffer = ByteBuffer.allocate(16); // or 32 characters
-    // Some users call the Stackdriver API and order results by traceId to get a "random sample" of
-    // traces. Duplicating the 64-bit ID instead of padding the ID with zeros will remove some
-    // sampling bias for any projects that contain both Zipkin and Stackdriver traces. Regardless of
-    // if we pad-left 0s or duplicate traceId, this resulting ID won't match Zipkin anyway as it
-    // conditionally encodes 16 characters if high bits are unset (as opposed to padding to 32).
-    idBuffer.putLong(zipkinSpan.traceIdHigh == 0L ? zipkinSpan.traceId : zipkinSpan.traceIdHigh);
+    // Note that when 64-bit trace IDs are used, the left-most 16 characters will be zero
+    idBuffer.putLong(zipkinSpan.traceIdHigh);
     idBuffer.putLong(zipkinSpan.traceId);
     StringBuilder idBuilder = new StringBuilder();
     for (byte b : idBuffer.array()) {

--- a/translation/src/test/java/com/google/cloud/trace/zipkin/translation/TraceTranslatorTest.java
+++ b/translation/src/test/java/com/google/cloud/trace/zipkin/translation/TraceTranslatorTest.java
@@ -51,19 +51,14 @@ public class TraceTranslatorTest {
         .containsExactly("00000000000000020000000000000001");
   }
 
-  /**
-   * Duplicating the lower 64 bits to construct a 128-bit trace ID removes bias when users sort on
-   * trace ID to choose a random traces. If instead we left-padded zeros, 64-bit traces would always
-   * appear first.
-   */
   @Test
-  public void testTranslateTrace_64BitTraceIdCopiedTwiceToMake128bits() {
+  public void testTranslateTrace_64BitTraceIdLeftPadsZeros() {
     Span span = Span.builder().id(1).traceId(1).name("/a").build();
     TraceTranslator translator = new TraceTranslator("test-project");
 
     assertThat(translator.translateSpans(Arrays.asList(span)))
         .extracting("traceId")
-        .containsExactly("00000000000000010000000000000001");
+        .containsExactly("00000000000000000000000000000001");
   }
 
   @Test
@@ -101,8 +96,8 @@ public class TraceTranslatorTest {
         trace1.getTraceId(), trace1,
         trace2.getTraceId(), trace2
     );
-    String key1 = "00000000000000010000000000000001";
-    String key2 = "00000000000000020000000000000002";
+    String key1 = "00000000000000000000000000000001";
+    String key2 = "00000000000000000000000000000002";
     assertTrue(traceMap.containsKey(key1));
     assertTrue(traceMap.containsKey(key2));
     assertEquals(2, traceMap.get(key1).getSpansCount());


### PR DESCRIPTION
This changes to the latest version of Zipkin and adjusts the code to use
128-bit trace ids as defined by Zipkin. This fills high bits with zero
when the trace doesn't have high bits set. This would occur when 64-bit
trace IDs are in use.