### PR TITLE
Create executable JAR instead: it can be used as init.d service

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -51,6 +51,9 @@
     <plugin>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-maven-plugin</artifactId>
+      <configuration>
+        <executable>true</executable>
+      </configuration>
       <executions>
         <execution>
           <goals>


### PR DESCRIPTION
Service can either started as executable `./collector/target/collector-0.1.1-SNAPSHOT.jar`, either can be installed as init.d service (that is what I plan to do) 

> denyska$ ./collector/target/collector-0.1.1-SNAPSHOT.jar 
> 
>   .   ____          _            __ _ _
>  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
> ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
>  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
>   '  |____| .__|_| |_|_| |_\__, | / / / /
>  =========|_|==============|___/=/_/_/_/
>  :: Spring Boot ::        (v1.4.1.RELEASE)
> 
> 2016-12-20 10:12:40.582  INFO 91472 --- [           main] c.g.c.t.z.StackdriverZipkinCollector     : Starting StackdriverZipkinCollector on denyska
