### PR TITLE
Added env variables to Docker runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,21 @@ additional configuration is required.
 ```
 java -jar collector.jar
 ```
+or just
+```
+./collector.jar
+```
+
+If docker is used from a GCE host, authentication will happen automatically and Zipkin collector can be started with:
+```
+docker run -p 9411:9411 b.gcr.io/stackdriver-trace-docker/zipkin-collector
+```
+
 
 #### Using an explicit projectId and credentials file path
 ```
 GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json" PROJECT_ID="my_project_id" java -jar collector.jar
 ```
-
-#### Using Docker
 ```
 docker run -v /path/to_credentials:/opt/gcloud -e GOOGLE_APPLICATION_CREDENTIALS="/opt/gcloud/credentials.json" -e PROJECT_ID="my_project_id" -p 9411:9411 b.gcr.io/stackdriver-trace-docker/zipkin-collector
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json" PROJECT_ID="my_projec
 
 #### Using Docker
 ```
-docker run -p 9411:9411 b.gcr.io/stackdriver-trace-docker/zipkin-collector
+docker run -v /path/to_credentials:/opt/gcloud -e GOOGLE_APPLICATION_CREDENTIALS="/opt/gcloud/credentials.json" -e PROJECT_ID="my_project_id" -p 9411:9411 b.gcr.io/stackdriver-trace-docker/zipkin-collector
 ```
 
 ## Storage


### PR DESCRIPTION
Made README.md more explicit: it was bit unclear how to run adapter within docker w/o credentials.