### PR TITLE
Made executor service configurable

### DIFF
--- a/autoconfigure-storage/pom.xml
+++ b/autoconfigure-storage/pom.xml
@@ -16,7 +16,15 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
-      <version>1.4.1.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.zipkin.java</groupId>

--- a/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageProperties.java
+++ b/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageProperties.java
@@ -22,6 +22,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ZipkinStackdriverStorageProperties {
   private String projectId;
   private String apiHost = "cloudtrace.googleapis.com";
+  private Executor executor = new Executor();
+
+  public Executor getExecutor()
+  {
+    return executor;
+  }
+
+  public void setExecutor(Executor executor)
+  {
+    this.executor = executor;
+  }
 
   public String getProjectId() {
     return projectId;
@@ -37,5 +48,48 @@ public class ZipkinStackdriverStorageProperties {
 
   public void setApiHost(String apiHost) {
     this.apiHost = apiHost;
+  }
+
+  public static class Executor
+  {
+    private int corePoolSize = 1;
+    private int maxPoolSize = 5;
+    private int queueCapacity = 2000;
+
+    public int getCorePoolSize()
+    {
+      return corePoolSize;
+    }
+
+    public int getMaxPoolSize()
+    {
+      return maxPoolSize;
+    }
+
+    public int getQueueCapacity()
+    {
+      return queueCapacity;
+    }
+
+    public void setCorePoolSize(int corePoolSize)
+    {
+      this.corePoolSize = corePoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize)
+    {
+      this.maxPoolSize = maxPoolSize;
+    }
+
+    public void setQueueCapacity(int queueCapacity)
+    {
+      this.queueCapacity = queueCapacity;
+    }
+
+    public String toString()
+    {
+      return "Executor(corePoolSize=" + this.getCorePoolSize()
+          + ", maxPoolSize=" + this.getMaxPoolSize() + ", queueCapacity=" + this.getQueueCapacity() + ")";
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,24 @@
     <zipkin.version>1.18.0</zipkin.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Import dependency management from Spring Boot -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>1.4.2.RELEASE</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>pl.pragmatists</groupId>
+        <artifactId>JUnitParams</artifactId>
+        <version>1.0.5</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <build>
     <pluginManagement>
       <plugins>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -44,6 +44,23 @@
       <artifactId>grpc-netty</artifactId>
       <version>1.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/storage/src/test/java/com/google/cloud/trace/zipkin/StackdriverStorageComponentTest.java
+++ b/storage/src/test/java/com/google/cloud/trace/zipkin/StackdriverStorageComponentTest.java
@@ -1,0 +1,116 @@
+package com.google.cloud.trace.zipkin;
+
+import com.google.cloud.trace.v1.sink.TraceSink;
+import com.google.devtools.cloudtrace.v1.Trace;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import zipkin.Span;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.Callback;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+@RunWith(JUnitParamsRunner.class)
+public class StackdriverStorageComponentTest
+{
+  private ThreadPoolTaskExecutor executor;
+
+  @After
+  public void after()
+  {
+    if (executor != null)
+    {
+      executor.destroy();
+    }
+  }
+
+  @Parameters({"5, 10, 100, 25"})
+  @Test
+  public void slowGRPC(final int corePoolSize, final int maxPoolSize, final long queueCapacity, final int grpcDelayInMillis)
+      throws InterruptedException
+  {
+    final int awaitTerminationInSeconds = 2;
+    final long maxCapacity = TimeUnit.SECONDS.toMillis(awaitTerminationInSeconds) * maxPoolSize / grpcDelayInMillis;
+
+    this.executor = new ThreadPoolTaskExecutor();
+    executor.setThreadNamePrefix("ZipkinStackdriverStorage-");
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.setCorePoolSize(corePoolSize);
+    executor.setMaxPoolSize(maxPoolSize);
+
+    executor.setQueueCapacity((int) queueCapacity);
+    executor.setAwaitTerminationSeconds(awaitTerminationInSeconds);
+    executor.initialize();
+
+    TraceSink sink = createSlowTraceSink(grpcDelayInMillis);
+    StackdriverStorageComponent component = new StackdriverStorageComponent("test", sink, executor);
+    final AsyncSpanConsumer consumer = component.asyncSpanConsumer();
+
+    long rejectCount = 0;
+    for (long i = 0; i < maxCapacity; i++)
+    {
+      try
+      {
+        consumer.accept(createTestSpans(i), Callback.NOOP);
+      }
+      catch (TaskRejectedException rejected)
+      {
+        rejectCount++;
+      }
+    }
+
+    executor.shutdown();
+
+    final long completedCount = executor.getThreadPoolExecutor().getCompletedTaskCount();
+    System.out.println(format("Rejected: %s, completed: %s", rejectCount, completedCount));
+
+    assertThat("At least one task has to be rejected", rejectCount, greaterThan(0l));
+    assertThat("Number of rejected + completed should be the same as number of samples", rejectCount + completedCount, equalTo(maxCapacity));
+    assertThat("Number of completed tasks should be less or equal than max executor capacity", completedCount, lessThanOrEqualTo(maxCapacity));
+    assertThat("Number of completed tasks should be at least of task queue size", completedCount, greaterThanOrEqualTo(queueCapacity));
+  }
+
+  private TraceSink createSlowTraceSink(final long grpcDelayInMillis)
+  {
+    return new TraceSink()
+    {
+      @Override
+      public void receive(Trace trace)
+      {
+        try
+        {
+          TimeUnit.MILLISECONDS.sleep(grpcDelayInMillis);
+        }
+        catch (InterruptedException e)
+        {
+          // no special handling
+          e.printStackTrace();
+        }
+      }
+    };
+  }
+
+  private List<Span> createTestSpans(long traceId)
+  {
+    return Arrays.asList(Span.builder()
+                             .traceId(traceId)
+                             .name("test-span")
+                             .id(5)
+                             .build());
+  }
+}

--- a/translation/pom.xml
+++ b/translation/pom.xml
@@ -24,15 +24,8 @@
       <version>0.1.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.5.2</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Before the change com.google.cloud.trace.zipkin.StackdriverStorageComponent was essentially single-threaded as ThreadPoolTaskExecutor it was using was configured with default values: corePoolSize = 1, maxPoolSize = Integer.MAX_VALUE, queueCapacity = Integer.MAX_VALUE 

From JAVA doc of java.util.concurrent.ThreadPoolExecutor

>  * When a new task is submitted in method {@link #execute(Runnable)},
>  * and fewer than corePoolSize threads are running, a new thread is
>  * created to handle the request, even if other worker threads are
>  * idle.  If there are more than corePoolSize but less than
>  * maximumPoolSize threads running, a new thread will be created only
>  * if the queue is full. 

That means unless queue reaches Integer.MAX_VALUE  no new threads would be allocated.

