### PR TITLE
Update to latest cloud-trace-java version

### DIFF
--- a/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageAutoConfiguration.java
+++ b/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageAutoConfiguration.java
@@ -18,8 +18,8 @@ package com.google.cloud.trace.zipkin.autoconfigure;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.trace.grpc.v1.GrpcTraceSink;
-import com.google.cloud.trace.v1.sink.TraceSink;
+import com.google.cloud.trace.grpc.v1.GrpcTraceConsumer;
+import com.google.cloud.trace.v1.consumer.TraceConsumer;
 import com.google.cloud.trace.zipkin.StackdriverStorageComponent;
 import com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
@@ -68,9 +68,9 @@ public class ZipkinStackdriverStorageAutoConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean(TraceSink.class)
-  TraceSink traceSink(Credentials credentials) throws IOException {
-    return new GrpcTraceSink(storageProperties.getApiHost(), credentials);
+  @ConditionalOnMissingBean(TraceConsumer.class)
+  TraceConsumer traceConsumer(Credentials credentials) throws IOException {
+    return GrpcTraceConsumer.create(storageProperties.getApiHost(), credentials);
   }
 
   @Bean
@@ -106,8 +106,8 @@ public class ZipkinStackdriverStorageAutoConfiguration {
     }
   }
 
-  @Bean StorageComponent storage(@Qualifier("stackdriverExecutor") Executor executor, TraceSink sink, @Qualifier("projectId")
+  @Bean StorageComponent storage(@Qualifier("stackdriverExecutor") Executor executor, TraceConsumer consumer, @Qualifier("projectId")
       String projectId) {
-    return new StackdriverStorageComponent(projectId, sink, executor);
+    return new StackdriverStorageComponent(projectId, consumer, executor);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
   <properties>
     <zipkin.version>1.18.0</zipkin.version>
+    <cloud.trace.sdk.version>0.1.0</cloud.trace.sdk.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <zipkin.version>1.18.0</zipkin.version>
-    <cloud.trace.sdk.version>0.1.0</cloud.trace.sdk.version>
+    <cloud.trace.sdk.version>0.3.0</cloud.trace.sdk.version>
   </properties>
 
   <dependencyManagement>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -31,12 +31,12 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud.trace</groupId>
-      <artifactId>v1</artifactId>
+      <artifactId>sink</artifactId>
       <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.trace</groupId>
-      <artifactId>grpc-sink</artifactId>
+      <groupId>com.google.cloud.trace.v1</groupId>
+      <artifactId>grpc-consumer</artifactId>
       <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>com.google.cloud.trace</groupId>
       <artifactId>v1</artifactId>
-      <version>0.1.0</version>
+      <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.trace</groupId>
       <artifactId>grpc-sink</artifactId>
-      <version>0.1.0</version>
+      <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/storage/src/main/java/com/google/cloud/trace/zipkin/StackdriverSpanConsumer.java
+++ b/storage/src/main/java/com/google/cloud/trace/zipkin/StackdriverSpanConsumer.java
@@ -16,9 +16,10 @@
 
 package com.google.cloud.trace.zipkin;
 
-import com.google.cloud.trace.v1.sink.TraceSink;
+import com.google.cloud.trace.v1.consumer.TraceConsumer;
 import com.google.cloud.trace.zipkin.translation.TraceTranslator;
 import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
 import java.util.Collection;
 import java.util.List;
 import zipkin.Span;
@@ -26,23 +27,21 @@ import zipkin.storage.StorageAdapters.SpanConsumer;
 
 /**
  * Consumes Zipkin spans, translates them to Stackdriver spans using a provided TraceTranslator, and
- * writes them a provided TraceSink.
+ * writes them to a provided Stackdriver {@link TraceConsumer}.
  */
 public class StackdriverSpanConsumer implements SpanConsumer {
 
   private final TraceTranslator translator;
-  private final TraceSink sink;
+  private final TraceConsumer consumer;
 
-  public StackdriverSpanConsumer(TraceTranslator translator, TraceSink sink) {
+  public StackdriverSpanConsumer(TraceTranslator translator, TraceConsumer consumer) {
     this.translator = translator;
-    this.sink = sink;
+    this.consumer = consumer;
   }
 
   @Override
   public void accept(List<Span> spans) {
     Collection<Trace> traces = translator.translateSpans(spans);
-    for (Trace t : traces) {
-      sink.receive(t);
-    }
+    consumer.receive(Traces.newBuilder().addAllTraces(traces).build());
   }
 }

--- a/storage/src/main/java/com/google/cloud/trace/zipkin/StackdriverStorageComponent.java
+++ b/storage/src/main/java/com/google/cloud/trace/zipkin/StackdriverStorageComponent.java
@@ -18,7 +18,7 @@ package com.google.cloud.trace.zipkin;
 
 import static zipkin.storage.StorageAdapters.blockingToAsync;
 
-import com.google.cloud.trace.v1.sink.TraceSink;
+import com.google.cloud.trace.v1.consumer.TraceConsumer;
 import com.google.cloud.trace.zipkin.translation.TraceTranslator;
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -37,9 +37,9 @@ public class StackdriverStorageComponent implements StorageComponent {
   private final TraceTranslator traceTranslator;
   private final AsyncSpanConsumer spanConsumer;
 
-  public StackdriverStorageComponent(String projectId, TraceSink sink, Executor executor) {
+  public StackdriverStorageComponent(String projectId, TraceConsumer consumer, Executor executor) {
     this.traceTranslator = new TraceTranslator(projectId);
-    this.spanConsumer = blockingToAsync(new StackdriverSpanConsumer(traceTranslator, sink), executor);
+    this.spanConsumer = blockingToAsync(new StackdriverSpanConsumer(traceTranslator, consumer), executor);
   }
 
   @Override

--- a/translation/pom.xml
+++ b/translation/pom.xml
@@ -19,9 +19,9 @@
       <version>${zipkin.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.trace</groupId>
-      <artifactId>v1</artifactId>
-      <version>${cloud.trace.sdk.version}</version>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-devtools-cloudtrace-v1</artifactId>
+      <version>0.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/translation/pom.xml
+++ b/translation/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.google.cloud.trace</groupId>
       <artifactId>v1</artifactId>
-      <version>0.1.0</version>
+      <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Also, remove reflection workaround added as part of https://github.com/GoogleCloudPlatform/stackdriver-zipkin/pull/16