### PR TITLE
Fix netty-tcnative-boringssl-static dependency

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -30,7 +30,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>1.1.33.Fork23</version>
-      <classifier>${os.detected.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The collector is throwing this exception when making an outgoing gRPC call:
```
Exception in thread "grpc-default-executor-1" java.lang.IllegalArgumentException: Jetty ALPN/NPN has not been properly configured.
	at io.grpc.netty.GrpcSslContexts.selectApplicationProtocolConfig(GrpcSslContexts.java:153)
	at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:130)
	at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:119)
	at io.grpc.netty.GrpcSslContexts.forClient(GrpcSslContexts.java:90)
	at io.grpc.netty.NettyChannelBuilder.createProtocolNegotiator(NettyChannelBuilder.java:265)
	at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory.newClientTransport(NettyChannelBuilder.java:324)
	at io.grpc.internal.CallCredentialsApplyingTransportFactory.newClientTransport(CallCredentialsApplyingTransportFactory.java:62)
	at io.grpc.internal.TransportSet.startNewTransport(TransportSet.java:215)
	at io.grpc.internal.TransportSet.obtainActiveTransport(TransportSet.java:192)
	at io.grpc.internal.ManagedChannelImpl$3.getTransport(ManagedChannelImpl.java:637)
	at io.grpc.internal.ManagedChannelImpl$3.getTransport(ManagedChannelImpl.java:579)
	at io.grpc.DummyLoadBalancerFactory$DummyLoadBalancer$1.get(DummyLoadBalancerFactory.java:135)
	at io.grpc.internal.DelayedClientTransport$2.run(DelayedClientTransport.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```