### PR TITLE
Ensure OpenSSL is available for GRPC/Netty.

### DIFF
--- a/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageAutoConfiguration.java
+++ b/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageAutoConfiguration.java
@@ -21,7 +21,9 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.trace.grpc.v1.GrpcTraceConsumer;
 import com.google.cloud.trace.v1.consumer.TraceConsumer;
 import com.google.cloud.trace.zipkin.StackdriverStorageComponent;
+import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
+import io.netty.handler.ssl.OpenSsl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,6 +72,7 @@ public class ZipkinStackdriverStorageAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean(TraceConsumer.class)
   TraceConsumer traceConsumer(Credentials credentials) throws IOException {
+    Preconditions.checkState(OpenSsl.isAvailable(), "OpenSsl required");
     return GrpcTraceConsumer.create(storageProperties.getApiHost(), credentials);
   }
 

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -15,6 +15,10 @@
     <start-class>com.google.cloud.trace.zipkin.StackdriverZipkinCollector</start-class>
   </properties>
 
+  <!--
+  Don't use embedded Tomcat as it conflicts with "netty-tcnative-boringssl-static"
+  See https://github.com/netty/netty-tcnative/issues/151
+  -->
   <dependencies>
     <dependency>
       <groupId>io.zipkin.java</groupId>

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -20,6 +20,16 @@
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin-server</artifactId>
       <version>${zipkin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jetty</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -45,13 +55,6 @@
     </dependency>
   </dependencies>
 <build>
-<extensions>
-  <extension>
-    <groupId>kr.motd.maven</groupId>
-    <artifactId>os-maven-plugin</artifactId>
-    <version>1.5.0.Final</version>
-  </extension>
-</extensions>
   <resources>
     <resource>
       <directory>src/main/resources</directory>

--- a/collector/src/test/java/com/google/cloud/trace/zipkin/StackdriverMockServer.java
+++ b/collector/src/test/java/com/google/cloud/trace/zipkin/StackdriverMockServer.java
@@ -7,14 +7,20 @@ import com.google.devtools.cloudtrace.v1.TraceServiceGrpc;
 import com.google.devtools.cloudtrace.v1.TraceSpan;
 import com.google.protobuf.Empty;
 import io.grpc.Server;
+import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.net.ssl.SSLException;
 import java.io.IOException;
+import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +35,23 @@ public class StackdriverMockServer extends TraceServiceGrpc.TraceServiceImplBase
 {
   private static final Logger LOG = LoggerFactory.getLogger(StackdriverMockServer.class);
 
+  static final SslContext CLIENT_SSL_CONTEXT ;
+  static final SslContext SERVER_SSL_CONTEXT ;
+
+  static
+  {
+    try
+    {
+      final SelfSignedCertificate cert = new SelfSignedCertificate("localhost");
+      CLIENT_SSL_CONTEXT = GrpcSslContexts.forClient().trustManager(cert.cert()).build();
+      SERVER_SSL_CONTEXT = GrpcSslContexts.forServer(cert.certificate(), cert.privateKey()).build();
+    }
+    catch (CertificateException|SSLException e)
+    {
+      throw new Error(e);
+    }
+  }
+
   private final int port;
   private final Server server;
 
@@ -39,7 +62,7 @@ public class StackdriverMockServer extends TraceServiceGrpc.TraceServiceImplBase
   public StackdriverMockServer(int port)
   {
     this.port = port;
-    this.server = NettyServerBuilder.forPort(port).addService(this).build();
+    this.server = NettyServerBuilder.forPort(port).sslContext(SERVER_SSL_CONTEXT).addService(this).build();
   }
 
   @PostConstruct


### PR DESCRIPTION
Depending on class loading order (Mac vs. Linux,  surefire vs. executable uber jar) OpenSSL was either available, either not. As result gRPC communication was broken (see https://github.com/GoogleCloudPlatform/stackdriver-zipkin/pull/18). 

The root cause is best described in https://github.com/netty/netty-tcnative/issues/151. In short `org.apache.tomcat.jni.Library` was not loading from **netty-tcnative-boringssl-static-1.1.33.Fork23.jar**, but rather from **tomcat-embed-core-8.5.6.jar** (brought by zipkin-server -> spring-boot-starter-tomcat transitive dependency) and tcnative was failing to load proper JNI library as result. 

cc @kevinmdavis @adriancole 