### PR TITLE
Increase default queue capacity

### DIFF
--- a/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageProperties.java
+++ b/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageProperties.java
@@ -54,7 +54,7 @@ public class ZipkinStackdriverStorageProperties {
   {
     private int corePoolSize = 1;
     private int maxPoolSize = 5;
-    private int queueCapacity = 2000;
+    private int queueCapacity = 200000;
 
     public int getCorePoolSize()
     {


### PR DESCRIPTION
Hopefully fixes https://github.com/spring-cloud/spring-cloud-sleuth/issues/493

Spans are getting dropped under heavy load.

I've tried to push 4500 spans over 2250 HTTP requests (2 spans per POST) with 10 threads using [default](https://github.com/GoogleCloudPlatform/stackdriver-zipkin/blob/master/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageProperties.java#L55) **stackdriverExecutor** params: corePoolSize = 1; maxPoolSize = 5; queueCapacity = 2000 . Unfortunately 142 spans dropped: 

```
2017-01-11 21:12:40.450  WARN 86291 --- [qtp534643569-20] zipkin.server.ZipkinHttpCollector        : Cannot store spans [7bcbf7fec05a69f0.7bcbf7fec05a69f0<:7bcbf7fec05a69f0, 438e36860fbb5d18.438e36860fbb5d18<:438e36860fbb5d18] due to TaskRejectedException(Executor [java.util.concurrent.ThreadPoolExecutor@128935a0[Running, pool size = 5, active threads = 5, queued tasks = 2000, completed tasks = 174]] did not accept task: Accept([{"traceId":"7bcbf7fec05a69f0","id":"7bcbf7fec05a69f0","name":"get","annotations":[{"timestamp":1484197954276000,"value":"sr","endpoint":{"serviceName":"service","ipv4":"127.0.0.1","port":8080}},{"timestamp":1484197954277000,"value":"ss","endpoint":{"serviceName":"service","ipv4":"127.0.0.1","port":8080}}],"binaryAnnotations":[{"key":"http.method","value":"GET","endpoint":{"serviceName":"service","ipv4":"127.0.0.1","port":8080}}]}, {"traceId":"438e36860fbb5d18","id":"438e36860fbb5d18","name":"get","annotations":[{"timestamp":1484197954276000,"value":"sr","endpoint":{"serviceName":"service","ipv4":"127.0.0.1","port":8080}},{"timestamp":1484197954277000,"value":"ss","endpoint":{"serviceName":"service","ipv4":"127.0.0.1","port":8080}}],"binaryAnnotations":[{"key":"http.method","value":"GET","endpoint":{"serviceName":"service","ipv4":"127.0.0.1","port":8080}}]}]))
```

Metrics: 
```
   "gauge.zipkin_collector.message_spans.http":2.0,
   "gauge.response.api.v1.spans":5.0,
   "gauge.zipkin_collector.message_bytes.http":869.0,
   "counter.status.202.api.v1.spans":2179,
   "counter.status.500.api.v1.spans":71,
   "counter.zipkin_collector.messages.http":2250,
   "counter.zipkin_collector.spans_dropped.http":142,
   "counter.zipkin_collector.bytes.http":1955250,
   "counter.zipkin_collector.spans.http":4500
```

Load test https://github.com/GoogleCloudPlatform/stackdriver-zipkin/compare/master...denyska:feature/dropped_traces?expand=1

We can probably increase default queue capacity 100x-1000X and still not cause  OOM inside Docker container (2GB ???) assuming each trace takes ~1kb 

cc @adriancole @kevinmdavis 