### PR TITLE
Added metrics for Stackdriver component

### DIFF
--- a/autoconfigure-storage/pom.xml
+++ b/autoconfigure-storage/pom.xml
@@ -47,6 +47,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageAutoConfiguration.java
+++ b/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageAutoConfiguration.java
@@ -74,24 +74,6 @@ public class ZipkinStackdriverStorageAutoConfiguration {
   }
 
   @Bean
-  PublicMetrics metrics(final ThreadPoolTaskExecutor executor) {
-    return new PublicMetrics()
-    {
-
-      @Override
-      public Collection<Metric<?>> metrics()
-      {
-        final ArrayList<Metric<?>> result = new ArrayList<>();
-
-        result.add(new Metric<>("gauge.zipkin_storage.stackdriver.active_threads", executor.getActiveCount()));
-        result.add(new Metric<>("gauge.zipkin_storage.stackdriver.queue_size", executor.getThreadPoolExecutor().getQueue().size()));
-
-        return result;
-      }
-    };
-  }
-
-  @Bean
   @ConditionalOnMissingBean(TraceConsumer.class)
   TraceConsumer traceConsumer(Credentials credentials) throws IOException {
     Preconditions.checkState(OpenSsl.isAvailable(), "OpenSsl required");

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -60,6 +60,10 @@
       <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/storage/src/main/java/com/google/cloud/trace/zipkin/StackdriverStorageComponent.java
+++ b/storage/src/main/java/com/google/cloud/trace/zipkin/StackdriverStorageComponent.java
@@ -21,7 +21,13 @@ import static zipkin.storage.StorageAdapters.blockingToAsync;
 import com.google.cloud.trace.v1.consumer.TraceConsumer;
 import com.google.cloud.trace.zipkin.translation.TraceTranslator;
 import java.io.IOException;
-import java.util.concurrent.Executor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.springframework.boot.actuate.endpoint.PublicMetrics;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.AsyncSpanStore;
 import zipkin.storage.SpanStore;
@@ -32,14 +38,24 @@ import zipkin.storage.StorageComponent;
  *
  * No SpanStore methods are implemented because read operations are not supported.
  */
-public class StackdriverStorageComponent implements StorageComponent {
+public class StackdriverStorageComponent implements StorageComponent, PublicMetrics
+{
 
   private final TraceTranslator traceTranslator;
   private final AsyncSpanConsumer spanConsumer;
+  private final ThreadPoolTaskExecutor executor;
+  private final LongAdder tracesSent;
 
-  public StackdriverStorageComponent(String projectId, TraceConsumer consumer, Executor executor) {
+  public StackdriverStorageComponent(String projectId, TraceConsumer consumer, ThreadPoolTaskExecutor executor) {
     this.traceTranslator = new TraceTranslator(projectId);
-    this.spanConsumer = blockingToAsync(new StackdriverSpanConsumer(traceTranslator, consumer), executor);
+    this.tracesSent = new LongAdder();
+    final TraceConsumer instrumentedConsumer = traces ->
+    {
+      consumer.receive(traces);
+      this.tracesSent.add(traces != null ? traces.getTracesCount() : 0);
+    };
+    this.spanConsumer = blockingToAsync(new StackdriverSpanConsumer(traceTranslator, instrumentedConsumer), executor);
+    this.executor = executor;
   }
 
   @Override
@@ -65,5 +81,25 @@ public class StackdriverStorageComponent implements StorageComponent {
   @Override
   public void close() throws IOException {
 
+  }
+
+  @Override
+  public Collection<Metric<?>> metrics()
+  {
+    final ArrayList<Metric<?>> result = new ArrayList<>();
+
+    result.add(new Metric<>("gauge.zipkin_storage.stackdriver.active_threads", executor.getActiveCount()));
+    result.add(new Metric<>("gauge.zipkin_storage.stackdriver.pool_size", executor.getPoolSize()));
+    result.add(new Metric<>("gauge.zipkin_storage.stackdriver.core_pool_size", executor.getCorePoolSize()));
+    result.add(new Metric<>("gauge.zipkin_storage.stackdriver.max_pool_size", executor.getMaxPoolSize()));
+    result.add(new Metric<>("gauge.zipkin_storage.stackdriver.queue_size", executor.getThreadPoolExecutor().getQueue().size()));
+    result.add(new Metric<>("counter.zipkin_storage.stackdriver.sent", tracesSent));
+
+    return result;
+  }
+
+  public void resetMetrics()
+  {
+    tracesSent.reset();
   }
 }


### PR DESCRIPTION
That is how metrics mightlook like on http://localhost:9411/metrics

```
   "gauge.zipkin_storage.stackdriver.active_threads":5,
   "gauge.zipkin_storage.stackdriver.pool_size":5,
   "gauge.zipkin_storage.stackdriver.core_pool_size":1,
   "gauge.zipkin_storage.stackdriver.max_pool_size":10,
   "gauge.zipkin_storage.stackdriver.queue_size":20,
   "counter.zipkin_storage.stackdriver.sent":99,
```