### PR TITLE
Uses latest zipkin library in support of simplified json format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   </scm>
 
   <properties>
-    <zipkin.version>1.22.0</zipkin.version>
+    <zipkin.version>1.30.2</zipkin.version>
     <cloud.trace.sdk.version>0.3.2</cloud.trace.sdk.version>
     <grpc.version>1.0.2</grpc.version>
   </properties>
@@ -53,7 +53,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>1.4.2.RELEASE</version>
+        <version>1.5.6.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/translation/pom.xml
+++ b/translation/pom.xml
@@ -35,5 +35,49 @@
     </dependency>
 
   </dependencies>
-
+  <build>
+    <plugins>
+      <!-- Repackage internal zipkin classes until Span2 is a public type -->
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <relocations>
+                <relocation>
+                  <pattern>zipkin.internal</pattern>
+                  <shadedPattern>com.google.cloud.trace.zipkin.translation.internal.zipkin</shadedPattern>
+                </relocation>
+              </relocations>
+              <artifactSet>
+                <includes>
+                  <include>io.zipkin.java:zipkin</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <!-- Shade references to span2 until zipkin2 is out -->
+                  <artifact>io.zipkin.java:zipkin</artifact>
+                  <includes>
+                    <include>zipkin/internal/*Span2*.class</include>
+                    <include>zipkin/internal/Util.class</include>
+                  </includes>
+                  <excludes>
+                    <exclude>*</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/translation/src/test/java/com/google/cloud/trace/zipkin/translation/TraceTranslatorTest.java
+++ b/translation/src/test/java/com/google/cloud/trace/zipkin/translation/TraceTranslatorTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
 import zipkin.Annotation;
+import zipkin.Endpoint;
 import zipkin.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +41,8 @@ import static zipkin.Constants.SERVER_RECV;
 import static zipkin.Constants.SERVER_SEND;
 
 public class TraceTranslatorTest {
+  Endpoint clientEp = Endpoint.builder().serviceName("client").build();
+  Endpoint serverEp = Endpoint.builder().serviceName("server").build();
 
   @Test
   public void testTranslateTrace_128bitInputTraceId() {
@@ -112,19 +115,19 @@ public class TraceTranslatorTest {
     Span span1 = Span.builder().traceId(1).id(1).name("/a")
         .timestamp(1474488796000000L) // This is set because the server owns the span
         .duration(5000000L)
-        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, serverEp))
         .build();
     Span span2 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?client")
         .timestamp(1474488797000000L) // This is set because the client owns the span.
         .duration(1500000L)
-        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, clientEp))
         .build();
     Span span3 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?server")
         // timestamp is not set because the server does not own this span.
-        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, serverEp))
         .build();
     Span span4 = Span.builder().traceId(1).parentId(2L).id(3).name("custom-span")
         .timestamp(1474488797600000L)
@@ -163,16 +166,16 @@ public class TraceTranslatorTest {
   @Test
   public void testMultihostServerRootSpan_noTimestamp() {
     Span span1 = Span.builder().traceId(1).id(1).name("/a")
-        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, serverEp))
         .build();
     Span span2 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?client")
-        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, clientEp))
         .build();
     Span span3 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?server")
-        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, serverEp))
         .build();
     Span span4 = Span.builder().traceId(1).parentId(2L).id(3).name("custom-span")
         .build();
@@ -208,24 +211,24 @@ public class TraceTranslatorTest {
     Span span1 = Span.builder().traceId(1).id(1).name("/a?client")
         .timestamp(1474488796000000L) // This is set because the client owns the span
         .duration(5000000L)
-        .addAnnotation(Annotation.create(1474488796000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488801000000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488796000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488801000000L, CLIENT_RECV, clientEp))
         .build();
     Span span2 = Span.builder().traceId(1).id(1).name("/a?server")
         // timestamp is not set because the server does not own this span.
-        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, serverEp))
         .build();
     Span span3 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?client")
         .timestamp(1474488797000000L) // This is set because the client owns the span.
         .duration(1500000L)
-        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, clientEp))
         .build();
     Span span4 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?server")
         // timestamp is not set because the server does not own this span.
-        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, serverEp))
         .build();
     Span span5 = Span.builder().traceId(1).parentId(2L).id(3).name("custom-span")
         .timestamp(1474488797600000L)
@@ -269,20 +272,20 @@ public class TraceTranslatorTest {
   @Test
   public void testMultihostClientRootSpan_noTimestamp() {
     Span span1 = Span.builder().traceId(1).id(1).name("/a?client")
-        .addAnnotation(Annotation.create(1474488796000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488801000000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488796000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488801000000L, CLIENT_RECV, clientEp))
         .build();
     Span span2 = Span.builder().traceId(1).id(1).name("/a?server")
-        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, serverEp))
         .build();
     Span span3 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?client")
-        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, clientEp))
         .build();
     Span span4 = Span.builder().traceId(1).parentId(1L).id(2).name("/b?server")
-        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, serverEp))
         .build();
     Span span5 = Span.builder().traceId(1).parentId(2L).id(3).name("custom-span")
         .build();
@@ -327,27 +330,27 @@ public class TraceTranslatorTest {
     Span span1 = Span.builder().traceId(1).id(1).name("/a?client")
         .timestamp(1474488796000000L) // This is set because the client owns the span
         .duration(5000000L)
-        .addAnnotation(Annotation.create(1474488796000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488801000000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488796000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488801000000L, CLIENT_RECV, clientEp))
         .build();
     Span span2 = Span.builder().traceId(1).parentId(1L).id(2).name("/a?server")
         .timestamp(1474488796000000L)
         .duration(5000000L)
-        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488796000000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488801000000L, SERVER_SEND, serverEp))
         .build();
     Span span3 = Span.builder().traceId(1).parentId(2L).id(3).name("/b?client")
         .timestamp(1474488797000000L) // This is set because the client owns the span.
         .duration(1500000L)
-        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, null))
-        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, null))
+        .addAnnotation(Annotation.create(1474488797000000L, CLIENT_SEND, clientEp))
+        .addAnnotation(Annotation.create(1474488798500000L, CLIENT_RECV, clientEp))
         .build();
     Span span4 = Span.builder().traceId(1).parentId(3L).id(4).name("/b?server")
         // timestamp is not set because the server does not own this span.
         .timestamp(1474488797500000L)
         .duration(800000L)
-        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, null))
-        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, null))
+        .addAnnotation(Annotation.create(1474488797500000L, SERVER_RECV, serverEp))
+        .addAnnotation(Annotation.create(1474488798300000L, SERVER_SEND, serverEp))
         .build();
     Span span5 = Span.builder().traceId(1).parentId(4L).id(5).name("custom-span")
         .timestamp(1474488797600000L)


### PR DESCRIPTION
This uses internal classes to perform a lot of the translation formerly
done here. By updating to latest zipkin, this also allows use of the new
POST /api/v2/spans endpoint from https://github.com/openzipkin/zipkin/issues/1499

I'm happy to support this including work to switch over to the public
zipkin2 types once they become available later this year. In the mean
time, this uses shade to ensure internal types aren't leaked.