### PR TITLE
Removes boringssl workaround by updating to latest gRPC

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -15,21 +15,11 @@
     <start-class>com.google.cloud.trace.zipkin.StackdriverZipkinCollector</start-class>
   </properties>
 
-  <!--
-  Don't use embedded Tomcat as it conflicts with "netty-tcnative-boringssl-static"
-  See https://github.com/netty/netty-tcnative/issues/151
-  -->
   <dependencies>
     <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin-server</artifactId>
       <version>${zipkin.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-tomcat</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -43,7 +33,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork23</version>
+      <version>${netty-boringssl.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/collector/src/test/java/com/google/cloud/trace/zipkin/ZipkinCollectorIntegrationTest.java
+++ b/collector/src/test/java/com/google/cloud/trace/zipkin/ZipkinCollectorIntegrationTest.java
@@ -53,11 +53,11 @@ import static java.lang.Math.min;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -130,7 +130,7 @@ public class ZipkinCollectorIntegrationTest
     }
     catch (StatusRuntimeException e)
     {
-      assertThat(e.getCause(), instanceOf(javax.net.ssl.SSLHandshakeException.class));
+      assertThat(e.getMessage(), endsWith("Channel closed while performing protocol negotiation"));
     }
 
     sslTraceService.patchTraces(PatchTracesRequest.getDefaultInstance());

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,9 @@
 
   <properties>
     <zipkin.version>1.30.2</zipkin.version>
-    <cloud.trace.sdk.version>0.3.2</cloud.trace.sdk.version>
-    <grpc.version>1.0.2</grpc.version>
+    <cloud.trace.sdk.version>0.4.0</cloud.trace.sdk.version>
+    <grpc.version>1.5.0</grpc.version>
+    <netty-boringssl.version>2.0.5.Final</netty-boringssl.version>
   </properties>
 
   <dependencyManagement>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -30,13 +30,13 @@
       <version>${zipkin.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.trace</groupId>
+      <groupId>com.google.cloud.trace.v1</groupId>
       <artifactId>sink</artifactId>
       <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud.trace.v1</groupId>
-      <artifactId>grpc-consumer</artifactId>
+      <groupId>com.google.cloud.trace</groupId>
+      <artifactId>trace-grpc-api-service</artifactId>
       <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>

--- a/translation/pom.xml
+++ b/translation/pom.xml
@@ -19,9 +19,9 @@
       <version>${zipkin.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-devtools-cloudtrace-v1</artifactId>
-      <version>0.1.0</version>
+      <groupId>com.google.cloud.trace</groupId>
+      <artifactId>trace-grpc-api-service</artifactId>
+      <version>${cloud.trace.sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>


### PR DESCRIPTION
Tested manually as well as unit tests. Removing the workaround allows this to work against a stock zipkin-server build.

See https://github.com/GoogleCloudPlatform/stackdriver-zipkin/pull/19#issuecomment-325263640