### PR TITLE
Fix bug related to api host not having the port.

### DIFF
--- a/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageProperties.java
+++ b/autoconfigure-storage/src/main/java/com/google/cloud/trace/zipkin/autoconfigure/ZipkinStackdriverStorageProperties.java
@@ -16,12 +16,13 @@
 
 package com.google.cloud.trace.zipkin.autoconfigure;
 
+import com.google.cloud.trace.v1.stub.TraceServiceStubSettings;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin.storage.stackdriver")
 public class ZipkinStackdriverStorageProperties {
   private String projectId;
-  private String apiHost = "cloudtrace.googleapis.com";
+  private String apiHost = TraceServiceStubSettings.getDefaultEndpoint();
   private Executor executor = new Executor();
 
   public Executor getExecutor()

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   </scm>
 
   <properties>
-    <zipkin.version>2.4.7</zipkin.version>
+    <zipkin.version>2.5.0</zipkin.version>
     <cloud.trace.sdk.version>0.7.0</cloud.trace.sdk.version>
     <grpc.version>1.9.0</grpc.version>
     <netty-boringssl.version>2.0.7.Final</netty-boringssl.version>


### PR DESCRIPTION
* Update the zipkin version to 2.5.0

Fixes https://github.com/GoogleCloudPlatform/stackdriver-zipkin/issues/57